### PR TITLE
Impelment better CLI logging in ts.manipulate

### DIFF
--- a/timestream/manipulate/__init__.py
+++ b/timestream/manipulate/__init__.py
@@ -5,20 +5,82 @@ from itertools import (
 import logging
 import multiprocessing
 
-CONSOLE = logging.getLogger("CONSOLE")
+
+NOEOL = logging.INFO+1
+logging.addLevelName(NOEOL, 'NOEOL')
+
+
+class NoEOLStreamHandler(logging.StreamHandler):
+    def __init__(self, stream=None):
+        super(NoEOLStreamHandler, self).__init__(stream)
+
+    def emit(self, record):
+        """
+        Emit a record. If level == NOEOL, don't add an EOL.
+        """
+        try:
+            # KDM: I've added this block, to get StreamHandler handle standard
+            # log levels.
+            if record.levelno != NOEOL:
+                return super(NoEOLStreamHandler, self).emit(record)
+            msg = self.format(record)
+            stream = self.stream
+            # KDM: this is the only other change from StreamHandler
+            # in StreamHandler, this is fs = "%s\n". We remove the EOL if
+            # log level is NOEOL. Everything else is the same.
+            fs = "%s"
+            if not logging._unicode: #if no unicode support...
+                stream.write(fs % msg)
+            else:
+                try:
+                    if (isinstance(msg, unicode) and
+                        getattr(stream, 'encoding', None)):
+                        ufs = fs.decode(stream.encoding)
+                        try:
+                            stream.write(ufs % msg)
+                        except UnicodeEncodeError:
+                            #Printing to terminals sometimes fails. For example,
+                            #with an encoding of 'cp1251', the above write will
+                            #work if written to a stream opened or wrapped by
+                            #the codecs module, but fail when writing to a
+                            #terminal even when the codepage is set to cp1251.
+                            #An extra encoding step seems to be needed.
+                            stream.write((ufs % msg).encode(stream.encoding))
+                    else:
+                        stream.write(fs % msg)
+                except UnicodeError:
+                    stream.write(fs % msg.encode("UTF-8"))
+            self.flush()
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except:
+            self.handleError(record)
+
+
+def setup_console_logger():
+    """Set up manipulation module CLI logging"""
+    log = logging.getLogger("CONSOLE")
+    fmt = logging.Formatter('%(asctime)s: %(message)s', '%H:%M:%S')
+    ch = NoEOLStreamHandler()
+    ch.setLevel(logging.INFO)
+    ch.setFormatter(fmt)
+    log.addHandler(ch)
+    log.setLevel(logging.INFO)
+
 
 def ts_parallel_map(ts_iter, func, args, procs=None):
     """Map ``func(item, *args)`` for each item in ``ts_iter`` in parallel"""
+    log = logging.getLogger("CONSOLE")
     # Setup pool
     if procs == None:
         procs = int(multiprocessing.cpu_count() * 0.9)
     pool = multiprocessing.Pool(procs)
-    CONSOLE.debug("Made pool with {:d} processes".format(procs))
+    log.debug("Made pool with {:d} processes".format(procs))
     # Setup args
     func_args = [ts_iter,]
     func_args.extend([cycle(arg) for arg in args])
     func_args = izip(*func_args)
-    CONSOLE.debug("Made argument list")
+    log.debug("Made argument list")
     # Run imap
     for ret in pool.imap(func, func_args):
         yield ret

--- a/timestream/manipulate/netcdf.py
+++ b/timestream/manipulate/netcdf.py
@@ -1,10 +1,18 @@
+import logging
 import netCDF4 as ncdf
 from netCDF4 import num2date, date2num, date2index
-from timestream.parse import ts_iter_images
-from timestream.parse import ts_iter_numpy
-from timestream.parse import ts_parse_date_path
+
+from timestream.manipulate import (
+        NOEOL,
+        )
+from timestream.parse import (
+        ts_iter_images,
+        ts_iter_numpy,
+        ts_parse_date_path,
+        )
 
 def ts_to_tsnc(ts_path, tsnc_path):
+    log = logging.getLogger("CONSOLE")
     # Get timestream images
     imgs = list(ts_iter_images(ts_path))
     mats = ts_iter_numpy(imgs)
@@ -26,12 +34,22 @@ def ts_to_tsnc(ts_path, tsnc_path):
     ys = root.createVariable("y", 'u4', ('y',))
     xs = root.createVariable("x", 'u4', ('x',))
     # create actual pixel array
-    pixels = root.createVariable("pixel", 'u1', ('t', 'y', 'x', 'z'), zlib=True)
+    pixels = root.createVariable("pixel", 'u1', ('t', 'y', 'x', 'z'),
+            zlib=True)
+    log.info("Created netcdf4 file {} with pixel array dimensions {!r}".format(
+        tsnc_path, pixels.shape))
     # iteratively add images
+    count = 0
     for img, mat in mats:
         n_dates = len(root.dimensions['t'])
         time = ts_parse_date_path(img)
         times[n_dates] = date2num([time,], units=times.units,
                 calendar=times.calendar)
         pixels[n_dates, :, :, :] = mat
+        count += 1
+        log.debug("Processed {}. Matrix shape is {!r}".format(img,
+            pixels.shape))
+        if count % 2 == 0:
+            log.log(NOEOL, "Processed {: 5d} images.\r".format(count))
+    log.info("Processed {: 5d} images. ts_to_tsnc finished!".format(count))
     root.close()


### PR DESCRIPTION
Got ahead of myself a bit before. So, we now have a consistent and easy way of logging CLI activity inside functions under ts.manipulate. And, we have a StreamHandler that can handled not adding EOLs, so we can use \r to have progress meters without endless spam.
