### PR TITLE
Add scikit image dependencies to preinstall_requirements.txt

### DIFF
--- a/preinstall_requirements.txt
+++ b/preinstall_requirements.txt
@@ -2,3 +2,5 @@ matplotlib==1.4.2
 numpy==1.8.1
 scipy==0.14.0
 cython==0.20.2
+networkx==1.9.1
+Pillow==2.6.1


### PR DESCRIPTION
This just adds a couple of dependencies to the `preinstall_requirements.txt` list. This fixes a problem with scikit image's installation.
