### PR TITLE
Remove the need for image files in tests.

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -4,6 +4,7 @@ import numpy as np
 import os
 from os import path
 import shutil
+import skimage.io
 
 
 LOG = logging.getLogger("timestreamlib")
@@ -52,14 +53,17 @@ FILES = {
 ZEROS_PIXELS = np.zeros((100, 100, 3), dtype="uint8")
 ZEROS_DATETIME = datetime.datetime(2013, 11, 12, 20, 53, 9)
 
+TS_FILES_JPG_PRE = \
+    "timestreams/good-timestream/2013/2013_10/2013_10_30/2013_10_30_"
 TS_FILES_JPG = [
-    "timestreams/good-timestream/2013/2013_10/2013_10_30/2013_10_30_03/good-timestream_2013_10_30_03_00_00_00.JPG",
-    "timestreams/good-timestream/2013/2013_10/2013_10_30/2013_10_30_03/good-timestream_2013_10_30_03_30_00_00.JPG",
-    "timestreams/good-timestream/2013/2013_10/2013_10_30/2013_10_30_04/good-timestream_2013_10_30_04_00_00_00.JPG",
-    "timestreams/good-timestream/2013/2013_10/2013_10_30/2013_10_30_04/good-timestream_2013_10_30_04_30_00_00.JPG",
-    "timestreams/good-timestream/2013/2013_10/2013_10_30/2013_10_30_05/good-timestream_2013_10_30_05_00_00_00.JPG",
-    "timestreams/good-timestream/2013/2013_10/2013_10_30/2013_10_30_05/good-timestream_2013_10_30_05_30_00_00.JPG",
-    "timestreams/good-timestream/2013/2013_10/2013_10_30/2013_10_30_06/good-timestream_2013_10_30_06_00_00_00.JPG",
+    TS_FILES_JPG_PRE + "03/good-timestream_2013_10_30_03_00_00_00.JPG",
+    TS_FILES_JPG_PRE + "03/good-timestream_2013_10_30_03_30_00_00.JPG",
+    TS_FILES_JPG_PRE + "04/good-timestream_2013_10_30_04_00_00_00.JPG",
+    TS_FILES_JPG_PRE + "04/good-timestream_2013_10_30_04_30_00_00.JPG",
+    TS_FILES_JPG_PRE + "05/good-timestream_2013_10_30_05_00_00_00.JPG",
+    TS_FILES_JPG_PRE + "05/good-timestream_2013_10_30_05_30_00_00.JPG",
+    TS_FILES_JPG_PRE + "06/good-timestream_2013_10_30_06_00_00_00.JPG",
+    TS_FILES_JPG_PRE + "06/good-timestream_2013_10_30_06_30_00_00.JPG",
 ]
 TS_JPG_DTYPE = 'uint8'
 TS_JPG_SHAPE = (35, 52, 3)
@@ -67,7 +71,7 @@ TS_JPG_SHAPE = (35, 52, 3)
 TS_DICT_PARSED = {
     "name": "good-timestream",
     "start_datetime": datetime.datetime(2013, 10, 30, 3, 0),
-    "end_datetime": datetime.datetime(2013, 10, 30, 6, 0),
+    "end_datetime": datetime.datetime(2013, 10, 30, 6, 30),
     "version": 1,
     "image_type": "jpg",
     "extension": "JPG",
@@ -78,7 +82,7 @@ TS_DICT_PARSED = {
 TS_DICT = {
     "name": "good-timestream",
     "start_datetime": "2013_10_30_03_00_00",
-    "end_datetime": "2013_10_30_06_00_00",
+    "end_datetime": "2013_10_30_06_30_00",
     "version": 1,
     "image_type": "jpg",
     "extension": "JPG",
@@ -86,16 +90,15 @@ TS_DICT = {
     "missing": [],
 }
 
-TS_STR = """TimeStream called good-timestream
-	path: {}
-	name: good-timestream
-	version: 1
-	start_datetime: 2013-10-30 03:00:00
-	end_datetime: 2013-10-30 06:00:00
-	image_type: jpg
-	extension: JPG
-	interval: 1800
-""".format(FILES["timestream"])
+TS_STR = "TimeStream called good-timestream\n" \
+         + "	path: {}\n".format(FILES["timestream"]) \
+         + "	name: good-timestream\n" \
+         + "	version: 1\n" \
+         + "	start_datetime: 2013-10-30 03:00:00\n" \
+         + "	end_datetime: 2013-10-30 06:30:00\n" \
+         + "	image_type: jpg\n" \
+         + "	extension: JPG\n" \
+         + "	interval: 1800\n" \
 
 TS_FILES_JPG = [path.join(TESTS_DIR, "data", x) for x in TS_FILES_JPG]
 
@@ -117,6 +120,7 @@ TS_DATES_PARSED = [
     datetime.datetime(2013, 10, 30, 5, 0),
     datetime.datetime(2013, 10, 30, 5, 30),
     datetime.datetime(2013, 10, 30, 6, 0),
+    datetime.datetime(2013, 10, 30, 6, 30),
 ]
 TS_GAPS_DATES_PARSED = [
     datetime.datetime(2013, 10, 30, 3, 0),
@@ -124,6 +128,7 @@ TS_GAPS_DATES_PARSED = [
     datetime.datetime(2013, 10, 30, 4, 0),
     datetime.datetime(2013, 10, 30, 5, 0),
     datetime.datetime(2013, 10, 30, 6, 0),
+    datetime.datetime(2013, 10, 30, 6, 30),
 ]
 
 if path.exists(FILES["empty_dir"]):
@@ -139,3 +144,32 @@ def make_tmp_file():
     global NUM_TEMPS
     NUM_TEMPS += 1
     return path.join(FILES["tmp_dir"], "{:05d}.tmp".format(NUM_TEMPS))
+
+
+def imgs_common_tsdir(act, fullpath, skip=None):
+    if fullpath.endswith(os.sep):
+        fullpath = fullpath[:-1]
+    dirname = path.basename(fullpath)
+    outimg = np.ones((35, 52, 3))
+
+    if act == "setup":
+        for h in ["03", "04", "05", "06"]:
+            D = path.join(fullpath, "2013", "2013_10", "2013_10_30",
+                          "2013_10_30_" + h)
+            if not path.isdir(D):
+                os.makedirs(D)
+            for m in ["00", "30"]:
+                if skip is not None and (h, m) in skip:
+                    continue
+                F = path.join(D, dirname + "_2013_10_30_"
+                              + h + "_" + m + "_00_00.JPG")
+                skimage.io.imsave(F, outimg)
+
+    elif act == "teardown":
+        top = path.join(fullpath, "2013")
+        for root, dirs, files in os.walk(top, topdown=False):
+            for name in files:
+                os.remove(os.path.join(root, name))
+            for name in dirs:
+                os.rmdir(os.path.join(root, name))
+        os.rmdir(top)

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -39,6 +39,10 @@ class TestTimeStreamStr(TestCase):
 
     """Test str(instance) of TimeStream classes."""
 
+    @classmethod
+    def setUpClass(cls):
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream"])
+
     def _check_ts_instance_ts_v1(self, ts_path):
         """Check members of a TimeStream class instance"""
 
@@ -48,10 +52,28 @@ class TestTimeStreamStr(TestCase):
         inst.load(helpers.FILES["timestream"])
         self.assertEqual(str(inst), helpers.TS_STR)
 
+    @classmethod
+    def tearDownClass(cls):
+        helpers.imgs_common_tsdir("teardown", helpers.FILES["timestream"])
+
 
 class TestTimeStreamLoad(TestCase):
 
     """Test loading of TimeStream classes. Tests read_metadata as well."""
+
+    @classmethod
+    def setUpClass(cls):
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream"])
+        helpers.imgs_common_tsdir("setup",
+                                  helpers.FILES["timestream_datafldr"])
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream_gaps"],
+                                  skip=[("04", "30"), ("05", "30")])
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream_imgdata"])
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream_bad"])
+        shutil.move(
+            path.join(helpers.FILES["timestream_bad"], "2013"),
+            path.join(path.dirname(helpers.FILES["timestream_bad"]),
+                      "broken_year_dir_2013"))
 
     def _check_ts_instance_ts_v1(self, ts_path):
         """Check members of a TimeStream class instance"""
@@ -114,6 +136,20 @@ class TestTimeStreamLoad(TestCase):
             self.assertIn("has_data", inst.image_data[img_date_str])
             self.assertIs(inst.image_data[img_date_str]["has_data"], True)
 
+    @classmethod
+    def tearDownClass(cls):
+        helpers.imgs_common_tsdir("teardown", helpers.FILES["timestream"])
+        helpers.imgs_common_tsdir("teardown",
+                                  helpers.FILES["timestream_datafldr"])
+        helpers.imgs_common_tsdir("teardown", helpers.FILES["timestream_gaps"])
+        helpers.imgs_common_tsdir("teardown",
+                                  helpers.FILES["timestream_imgdata"])
+        shutil.move(
+            path.join(path.dirname(helpers.FILES["timestream_bad"]),
+                      "broken_year_dir_2013"),
+            path.join(helpers.FILES["timestream_bad"], "2013"))
+        helpers.imgs_common_tsdir("teardown", helpers.FILES["timestream_bad"])
+
 
 class TestTimeStreamInit(TestCase):
 
@@ -162,6 +198,10 @@ class TestTimeStreamImagePathAssing(TestCase):
 
     """Test TimeStreamImage() path assignment"""
 
+    @classmethod
+    def setUpClass(cls):
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream"])
+
     def test_ts_image_path_assign(self):
         """Test TimeStreamImage. path assignment with valid parameters"""
         img = TimeStreamImage()
@@ -185,6 +225,10 @@ class TestTimeStreamImagePathAssing(TestCase):
         img.path = helpers.TS_FILES_JPG[0]
         self.assertEqual(img.path, helpers.TS_FILES_JPG[0])
         self.assertEqual(img.datetime, helpers.TS_DATES_PARSED[0])
+
+    @classmethod
+    def tearDownClass(cls):
+        helpers.imgs_common_tsdir("teardown", helpers.FILES["timestream"])
 
 
 class TestTimeStreamImageClone(TestCase):
@@ -229,6 +273,10 @@ class TestTimeStreamIterByFiles(TestCase):
 
     """Test TimeStream().iter_by_files()"""
 
+    @classmethod
+    def setUpClass(cls):
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream"])
+
     def test_iter_by_files(self):
         """Test TimeStream().iter_by_files with a good timestream"""
         ts = TimeStream()
@@ -244,10 +292,20 @@ class TestTimeStreamIterByFiles(TestCase):
             self.assertEqual(image.pixels.dtype, helpers.TS_JPG_DTYPE)
             self.assertEqual(image.pixels.shape, helpers.TS_JPG_SHAPE)
 
+    @classmethod
+    def tearDownClass(cls):
+        helpers.imgs_common_tsdir("teardown", helpers.FILES["timestream"])
+
 
 class TestTimeStreamIterByTimepoints(TestCase):
 
     """Test TimeStream().iter_by_timepoints"""
+
+    @classmethod
+    def setUpClass(cls):
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream"])
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream_gaps"],
+                                  skip=[("04", "30"), ("05", "30")])
 
     def test_iter_by_timepoints_full(self):
         """Test TimeStream().iter_by_timepoints with a complete timestream"""
@@ -302,6 +360,11 @@ class TestTimeStreamIterByTimepoints(TestCase):
             # We don't check pixels to save time. We know if this fails, it
             # will fail above, or be a problem in our data files which should
             # change the date and make the previous statement fail.
+
+    @classmethod
+    def tearDownClass(cls):
+        helpers.imgs_common_tsdir("teardown", helpers.FILES["timestream"])
+        helpers.imgs_common_tsdir("teardown", helpers.FILES["timestream_gaps"])
 
 
 class TestTimeStreamCreate(TestCase):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -24,6 +24,10 @@ class TestAllFilesWithExt(TestCase):
     _multiprocess_can_split_ = True
     maxDiff = None
 
+    @classmethod
+    def setUpClass(cls):
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream"])
+
     def test_with_timestream_ext_jpg(self):
         res = all_files_with_ext(helpers.FILES["timestream"], "jpg")
         self.assertTrue(isgenerator(res))
@@ -70,11 +74,19 @@ class TestAllFilesWithExt(TestCase):
         with self.assertRaises(ValueError):
             list(all_files_with_ext(".", "jpg", cs="No"))
 
+    @classmethod
+    def tearDownClass(cls):
+        helpers.imgs_common_tsdir("teardown", helpers.FILES["timestream"])
+
 
 class TestAllFilesWithExts(TestCase):
     """Test function timestream.parse.all_files_with_exts"""
     _multiprocess_can_split_ = True
     maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream"])
 
     def test_with_timestream_ext_jpg(self):
         res = all_files_with_exts(helpers.FILES["timestream"],
@@ -94,11 +106,19 @@ class TestAllFilesWithExts(TestCase):
         self.assertTrue(isinstance(res, dict))
         self.assertDictEqual(res, {"JPG": helpers.TS_FILES_JPG})
 
+    @classmethod
+    def tearDownClass(cls):
+        helpers.imgs_common_tsdir("teardown", helpers.FILES["timestream"])
+
 
 class TestIterImages(TestCase):
     """Test function timestream.parse.ts_iter_images"""
     _multiprocess_can_split_ = True
     maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream"])
 
     def test_good_timestream(self):
         """Test ts_iter_images with a timestream with a manifold"""
@@ -106,11 +126,19 @@ class TestIterImages(TestCase):
         self.assertTrue(isgenerator(res))
         self.assertListEqual(list(res), helpers.TS_FILES_JPG)
 
+    @classmethod
+    def tearDownClass(cls):
+        helpers.imgs_common_tsdir("teardown", helpers.FILES["timestream"])
+
 
 class TestGuessManifest(TestCase):
     """Tests for timestream.parse.ts_guess_manifest"""
     _multiprocess_can_split_ = True
     maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream"])
 
     def test_good_ts(self):
         got = ts_guess_manifest(helpers.FILES["timestream"])
@@ -122,11 +150,19 @@ class TestGuessManifest(TestCase):
         self.assertTrue(isinstance(got, dict))
         self.assertDictEqual(got, helpers.TS_DICT)
 
+    @classmethod
+    def tearDownClass(cls):
+        helpers.imgs_common_tsdir("teardown", helpers.FILES["timestream"])
+
 
 class TestGetImage(TestCase):
     """Test function timestream.parse.ts_get_image"""
     _multiprocess_can_split_ = True
     maxDiff = None
+
+    @classmethod
+    def setUpClass(cls):
+        helpers.imgs_common_tsdir("setup", helpers.FILES["timestream"])
 
     def test_get_image_good_str(self):
         """Test ts_get_image with a str date on a good timestream"""
@@ -173,6 +209,10 @@ class TestGetImage(TestCase):
             # bad subsecond param
             ts_get_image(helpers.FILES["timestream"],
                          helpers.TS_DATES[0], n="this should be an int")
+
+    @classmethod
+    def tearDownClass(cls):
+        helpers.imgs_common_tsdir("teardown", helpers.FILES["timestream"])
 
 
 class TestParseDate(TestCase):


### PR DESCRIPTION
This PR does away with needing actual images to do the class and parse tests. This means that instead of needing 1.6M of test data we now just need 928K. There might be even more ways of reducing data/timestream-good-images but it might be a bit more work that what I have done in the past week.

Please consider this for merging.
